### PR TITLE
feat(buttons): add support for background, text color, left and right icon

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Running the Playground
 
 ```
+cd playground
 flutter run -t playground/lib/main.dart
 flutter run -d chrome
 ```

--- a/lib/src/calls_to_action/button.dart
+++ b/lib/src/calls_to_action/button.dart
@@ -1,11 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:wrafl/src/communications/icon.dart';
 
 class WraflButton extends StatelessWidget {
   final String label;
+  final Color? backgroundColor;
+  final Color? textColor;
+  final Widget? leftIcon;
+  final Widget? rightIcon;
+  final bool? hideLabel;
+  final bool? disabled;
+  final bool? showSpinner;
   final VoidCallback onPressed;
 
   const WraflButton({
     Key? key,
+    this.backgroundColor,
+    this.textColor,
+    this.leftIcon,
+    this.rightIcon,
+    this.hideLabel = false,
+    this.disabled = false,
+    this.showSpinner = false,
     required this.label,
     required this.onPressed,
   }) : super(key: key);
@@ -13,8 +29,32 @@ class WraflButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        backgroundColor:
+            backgroundColor ?? Colors.blue, // Default background color if null
+        foregroundColor:
+            textColor ?? Colors.white, // Default text color if null
+      ),
       onPressed: onPressed,
-      child: Text(label),
+      child: Row(
+        mainAxisSize: MainAxisSize.min, // Make the button shrink to fit content
+        children: [
+          if (leftIcon != null) ...[
+            leftIcon!,
+            if (hideLabel == false) const SizedBox(width: 8.0),
+          ],
+          if (hideLabel == false) Text(label),
+          if (showSpinner == true) ...[
+            if (hideLabel == false || leftIcon != null) const SizedBox(width: 8.0),
+            const WraflIcon(
+                icon: FontAwesomeIcons.spinner, color: Colors.blue),
+          ],
+          if (rightIcon != null) ...[
+            if (hideLabel == false) const SizedBox(width: 8.0),
+            rightIcon!,
+          ],
+        ],
+      ),
     );
   }
 }

--- a/lib/src/calls_to_action/button.dart
+++ b/lib/src/calls_to_action/button.dart
@@ -8,9 +8,9 @@ class WraflButton extends StatelessWidget {
   final Color? textColor;
   final Widget? leftIcon;
   final Widget? rightIcon;
-  final bool? hideLabel;
-  final bool? disabled;
-  final bool? showSpinner;
+  final bool hideLabel;
+  final bool disabled;
+  final bool showSpinner;
   final VoidCallback onPressed;
 
   const WraflButton({
@@ -35,7 +35,7 @@ class WraflButton extends StatelessWidget {
         foregroundColor:
             textColor ?? Colors.white, // Default text color if null
       ),
-      onPressed: onPressed,
+      onPressed: disabled ? null : onPressed,
       child: Row(
         mainAxisSize: MainAxisSize.min, // Make the button shrink to fit content
         children: [

--- a/lib/src/communications/icon.dart
+++ b/lib/src/communications/icon.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class WraflIcon extends StatelessWidget {
+  final IconData icon;
+  final Color? color;
+  final double? size;
+
+  const WraflIcon({
+    Key? key,
+    required this.icon,
+    this.color,
+    this.size,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return FaIcon(
+      icon,
+      color: color ?? Colors.black,
+      size: size ?? 16.0,
+    );
+  }
+}

--- a/playground/lib/code_snippet.dart
+++ b/playground/lib/code_snippet.dart
@@ -19,7 +19,7 @@ class CodeSnippet extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 20),
+        const SizedBox(height: 50),
         Center(child: child), // Center the child widget
         const SizedBox(height: 100),
         const Center(

--- a/playground/lib/code_snippet.dart
+++ b/playground/lib/code_snippet.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'; // For Clipboard
+
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/github.dart';
+
+class CodeSnippet extends StatelessWidget {
+  final Widget child;
+  final String code;
+
+  const CodeSnippet({
+    Key? key,
+    required this.child,
+    required this.code,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 20),
+        Center(child: child), // Center the child widget
+        const SizedBox(height: 100),
+        const Center(
+          child: Text(
+            'Code Snippet:',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        const SizedBox(height: 20),
+        Center(
+          child: HighlightView(
+            // The original code to be highlighted
+            code,
+
+            // Specify language
+            // It is recommended to give it a value for performance
+            language: 'dart',
+
+            // Specify highlight theme
+            // All available themes are listed in `themes` folder
+            theme: githubTheme,
+
+            // Specify padding
+            padding: const EdgeInsets.all(12),
+
+            // Specify text style
+            textStyle: const TextStyle(
+              fontFamily: 'My awesome monospace font',
+              fontSize: 16,
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Center(
+          child: ElevatedButton(
+            onPressed: () {
+              // Copy code to clipboard
+              Clipboard.setData(ClipboardData(text: code)).then((_) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Code copied to clipboard!')),
+                );
+              });
+            },
+            child: const Text('Copy Code'),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/playground/lib/stories/call_to_action/button_stories.dart
+++ b/playground/lib/stories/call_to_action/button_stories.dart
@@ -1,16 +1,29 @@
-// ignore: implementation_imports
+// ignore_for_file: implementation_imports
 
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:storybook_flutter/storybook_flutter.dart';
+
+// WraFL Buttons.
 import 'package:wrafl/src/calls_to_action/button.dart';
+import 'package:wrafl/src/communications/icon.dart';
+import 'package:playground/code_snippet.dart';
 
 List<Story> wraflButtonStories = [
   Story(
     name: 'Call To Action/WraflButton/Default',
     builder: (context) {
-      return Center(
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Default Button',
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
         child: WraflButton(
-          label: 'Press Me!',
+          label: 'Default Button',
           onPressed: () {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Button Pressed!')),
@@ -23,17 +36,26 @@ List<Story> wraflButtonStories = [
   Story(
     name: 'Call To Action/WraflButton/Background Color',
     builder: (context) {
-      const color = Colors.blue;
+      const color = Colors.green;
 
-      return Center(
-        child: ElevatedButton(
-          style: ElevatedButton.styleFrom(backgroundColor: color),
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Green Background Color',
+          backgroundColor: color,
           onPressed: () {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Button Pressed!')),
             );
           },
-          child: const Text('Press Me!'),
+        )''',
+        child: WraflButton(
+          label: 'Green Background Color',
+          backgroundColor: color,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
         ),
       );
     },
@@ -41,17 +63,165 @@ List<Story> wraflButtonStories = [
   Story(
     name: 'Call To Action/WraflButton/Text Color',
     builder: (context) {
-      const color = Colors.blue;
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
 
-      return Center(
-        child: ElevatedButton(
-          style: ElevatedButton.styleFrom(backgroundColor: color),
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Blue Text Color in white',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
           onPressed: () {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Button Pressed!')),
             );
           },
-          child: const Text('Press Me!'),
+        )''',
+        child: WraflButton(
+          label: 'Blue Text Color in white',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        ),
+      );
+    },
+  ),
+  Story(
+    name: 'Call To Action/WraflButton/Left Icon',
+    builder: (context) {
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
+
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Clipboard',
+          hideLabel: true,
+          leftIcon: const WraflIcon(
+              icon: FontAwesomeIcons.clipboard, color: Colors.blue),
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
+        child: WraflButton(
+          label: 'Clipboard',
+          hideLabel: true,
+          leftIcon: const WraflIcon(
+              icon: FontAwesomeIcons.clipboard, color: Colors.blue),
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        ),
+      );
+    },
+  ),
+  Story(
+    name: 'Call To Action/WraflButton/Left Icon + Label',
+    builder: (context) {
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
+
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Search',
+          leftIcon: const WraflIcon(
+              icon: FontAwesomeIcons.magnifyingGlass, color: Colors.blue),
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
+        child: WraflButton(
+          label: 'Search',
+          leftIcon: const WraflIcon(
+              icon: FontAwesomeIcons.magnifyingGlass, color: Colors.blue),
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        ),
+      );
+    },
+  ),
+  Story(
+    name: 'Call To Action/WraflButton/With Spinner',
+    builder: (context) {
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
+
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Searching...',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          showSpinner: true,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
+        child: WraflButton(
+          label: 'Searching...',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          showSpinner: true,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        ),
+      );
+    },
+  ),
+  Story(
+    name: 'Call To Action/WraflButton/Right Icon',
+    builder: (context) {
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
+
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Actions',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          rightIcon: const WraflIcon(
+              icon: FontAwesomeIcons.chevronDown, color: Colors.blue),
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
+        child: WraflButton(
+          label: 'Actions',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          rightIcon: const WraflIcon(
+              icon: FontAwesomeIcons.chevronDown, color: Colors.blue),
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
         ),
       );
     },

--- a/playground/lib/stories/call_to_action/button_stories.dart
+++ b/playground/lib/stories/call_to_action/button_stories.dart
@@ -193,6 +193,38 @@ List<Story> wraflButtonStories = [
     },
   ),
   Story(
+    name: 'Call To Action/WraflButton/Disabled',
+    builder: (context) {
+      const backgroundColor = Colors.white;
+      const foregroundColor = Colors.blue;
+
+      return CodeSnippet(
+        code: '''WraflButton(
+          label: 'Searching...',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          disabled: true,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        )''',
+        child: WraflButton(
+          label: 'Searching...',
+          backgroundColor: backgroundColor,
+          textColor: foregroundColor,
+          disabled: true,
+          onPressed: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Button Pressed!')),
+            );
+          },
+        ),
+      );
+    },
+  ),
+  Story(
     name: 'Call To Action/WraflButton/Right Icon',
     builder: (context) {
       const backgroundColor = Colors.white;

--- a/playground/pubspec.yaml
+++ b/playground/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  font_awesome_flutter: ^10.7.0
+  flutter_highlight: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   dashbook: ^0.1.13
   flutter:
     sdk: flutter
+  font_awesome_flutter: ^10.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Context
1. Add Code Snippet Widget for copy code feature in playground app
1. Add New Icon Widget backed by FontAwesome

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/7f2d1696-de53-45c3-b2cf-b06fdbd5a496">
