### PR TITLE
feat(communications/icon): add stories for icon widget

### DIFF
--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:storybook_flutter/storybook_flutter.dart';
 
 // Call to Action - Stories
 import 'package:playground/stories/call_to_action/button_stories.dart';
+import 'package:playground/stories/communications/icon_stories.dart';
 
 void main() {
   runApp(const PlaygroundApp());
@@ -36,6 +37,7 @@ class StorybookWidget extends StatelessWidget {
     return Storybook(
       stories: [
         ...wraflButtonStories, // WraflButton Stories.
+        ...wraflIconStories, // WraflIcon Stories.
       ],
     );
   }

--- a/playground/lib/stories/communications/icon_stories.dart
+++ b/playground/lib/stories/communications/icon_stories.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:storybook_flutter/storybook_flutter.dart';
+import 'package:playground/code_snippet.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+// WraFL Communications. 
+import 'package:wrafl/src/communications/icon.dart';
+
+List<Story> wraflIconStories = [
+    Story(
+        name: 'Communications/Icon/Default',
+        builder: (context) {
+            return CodeSnippet(
+                code: 
+                '''
+                child: WraflIcon(
+                    icon: FontAwesomeIcons.home,
+                )
+                ''',
+                child: WraflIcon(
+                    icon: FontAwesomeIcons.home,
+                ),
+            );
+        }
+    ),
+     Story(
+        name: 'Communications/Icon/Size',
+        builder: (context) {
+            return CodeSnippet(
+                code: 
+                '''
+               child: WraflIcon(
+                    icon: FontAwesomeIcons.envelope,
+                    size: 40.0,
+                )
+                ''',
+                child: WraflIcon(
+                    icon: FontAwesomeIcons.envelope,
+                    size: 40.0,
+                ),
+            );
+        }
+    ),  Story(
+        name: 'Communications/Icon/Color',
+        builder: (context) {
+            return CodeSnippet(
+                code: 
+                '''
+                child: WraflIcon(
+                    icon: FontAwesomeIcons.envelope,
+                    color: Colors.purple,
+                    size: 40.0,
+                )
+                ''',
+                child: WraflIcon(
+                    icon: FontAwesomeIcons.envelope,
+                    color: Colors.purple,
+                    size: 40.0,
+                ),
+            );
+        }
+    ), 
+   
+   
+];
+


### PR DESCRIPTION
## Context
Update Playground | Add Icon Story to Playground

<img width="839" alt="Screenshot 2024-09-10 at 8 15 00 PM" src="https://github.com/user-attachments/assets/2713ce10-9486-4942-9bdb-d71647db8e95">
